### PR TITLE
Parallel `mix cotton.lint`

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -33,7 +33,7 @@
       # If you want to enforce a style guide and need a more traditional linting
       # experience, you can change `strict` to `true` below:
       #
-      strict: false,
+      strict: true,
       #
       # If you want to use uncolored output by default, you can change `color`
       # to `false` below:
@@ -77,7 +77,7 @@
 
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 120},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,7 @@
 [
   inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"],
   export: [
-    line_length: 80,
+    line_length: 120,
     locals_without_parens: []
   ]
 ]


### PR DESCRIPTION
Close #5

```console
% mix cotton.lint
Checking PLT...
Checking 4 source files ...
[:asn1, :certifi, :compiler, :crypto, :elixir, :excoveralls, :exjsx, :hackney,
 :idna, :jsx, :kernel, :metrics, :mimerl, :mix, :public_key, :ssl,
 :ssl_verify_fun, :stdlib, :stream_data, :unicode_util_compat]
PLT is up to date!
Starting Dialyzer
dialyzer args: [
  check_plt: false,
  init_plt: '/Users/inoue_sachiro/dev/inner_cotton/_build/dev/dialyxir_erlang-20.2.3_elixir-1.6.1_deps-dev.plt',
  files_rec: ['/Users/inoue_sachiro/dev/inner_cotton/_build/dev/lib/inner_cotton/ebin'],
  warnings: [:unknown]
]

Please report incorrect results: https://github.com/rrrene/credo/issues

Analysis took 0.2 seconds (0.02s to load, 0.1s running checks)
14 mods/funs, found no issues.


# Properly documented, could be improved:                                       
â  B  â  Mix.Tasks.Cotton.Watch.run/1
â  B  â  Mix.Tasks.Cotton.Init.run/1
â  B  â  Mix.Tasks.Cotton.Lint.run/1
â  B  â  Mix.Tasks.Cotton.run/1

You might want to look at these files:

â /lib/mix/tasks/cotton.watch.ex
â /lib/mix/tasks/cotton.lint.ex
â /lib/mix/tasks/cotton.init.ex
â /lib/mix/tasks/cotton.ex

Grade distribution (undocumented, C, B, A):  â  â â â

Considering priority objects: â â â â â  (use `--help` for options).
done in 0m1.91s
done (passed successfully)
format   :	ok
credo    :	ok
dialyzer :	ok
inch     :	ok
```